### PR TITLE
Support YouTube live URLs

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,20 +1,24 @@
-const isYoutube = (url) => {
-  if (!url) return false;
+const isYoutube = (urlStr) => {
+  if (!urlStr) return false;
 
-  let parsed;
+  let url;
   try {
-    parsed = new URL(url);
+    url = new URL(urlStr);
   } catch (_e) {
     return false;
   }
 
-  const hostname = parsed.hostname.toLowerCase();
+  const hostname = url.hostname.toLowerCase();
   if (hostname !== "youtube.com" && !hostname.endsWith(".youtube.com")) {
     return false;
   }
 
-  const pathname = parsed.pathname;
-  return pathname.startsWith("/watch") || pathname.startsWith("/shorts");
+  const pathname = url.pathname;
+  return (
+    (pathname.startsWith("/watch") && !!url.searchParams.get("v")) ||
+    /^\/shorts\/[^/]+/.test(pathname) ||
+    /^\/live\/[^/]+/.test(pathname)
+  );
 };
 
 browser.tabs.onUpdated.addListener(

--- a/popup/index.js
+++ b/popup/index.js
@@ -54,9 +54,12 @@ const parseVideoId = (urlString) => {
   const vParam = url.searchParams.get("v");
   if (vParam) return { videoId: vParam, isShorts: false };
 
-  const path = url.pathname;
-  const shortsMatch = path.match(/^\/shorts\/([^/?#]+)/);
+  const pathname = url.pathname;
+  const shortsMatch = pathname.match(/^\/shorts\/([^/]+)/);
   if (shortsMatch) return { videoId: shortsMatch[1], isShorts: true };
+
+  const liveMatch = pathname.match(/^\/live\/([^/]+)/);
+  if (liveMatch) return { videoId: liveMatch[1], isShorts: false };
 
   return { videoId: null, isShorts: false };
 };


### PR DESCRIPTION
## Summary
- support YouTube `https://youtube.com/live/<id>` URLs in the popup thumbnail parser
- show the page action for `/live/` pages as well as existing watch and shorts URLs
- tighten `/shorts/` and `/live/` path matching so URL detection stays aligned with video ID parsing

## Validation
- `npm run lint`