### PR TITLE
Adapt page action icon for themes

### DIFF
--- a/icons/page_action.svg
+++ b/icons/page_action.svg
@@ -1,1 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black" width="18px" height="18px"><path d="M0 0h24v24H0z" fill="none"/><path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-8 12.5v-9l6 4.5-6 4.5z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" width="20px" height="20px">
+  <style>
+    .icon {
+      fill: #5b5b66;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .icon {
+        fill: #fbfbfe;
+      }
+    }
+  </style>
+  <path
+    class="icon"
+    d="m456-384 264-168-264-168v336ZM312-240q-29.7 0-50.85-21.15Q240-282.3 240-312v-480q0-29.7 21.15-50.85Q282.3-864 312-864h480q29.7 0 50.85 21.15Q864-821.7 864-792v480q0 29.7-21.15 50.85Q821.7-240 792-240H312Zm0-72h480v-480H312v480ZM168-96q-29.7 0-50.85-21.15Q96-138.3 96-168v-552h72v552h552v72H168Zm144-696v480-480Z"
+  />
+</svg>


### PR DESCRIPTION
## Summary
- replace the page action SVG's fixed black fill with theme-aware colors for Firefox light and dark UI
- update the icon asset to the new 20px Material-style path while keeping it as a single SVG asset
- use Firefox Acorn icon color tokens (`#5b5b66` for light UI and `#fbfbfe` for dark UI)

## Motivation
The address bar icon was hard to see in dark mode because the previous asset used a fixed fill color. This updates the icon so it remains visible in both Firefox light and dark themes.

## Validation
- No automated tests were run; the change only updates `icons/page_action.svg`
- Visual appearance in both dark and light mode was checked during development

## User-visible impact
The page action icon in the Firefox address bar should now remain legible in both light and dark themes.

## Risks / notes
Firefox may apply version-dependent SVG icon filtering in dark UI themes, but this change follows the documented `prefers-color-scheme` approach for WebExtension action icons.